### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Placid.app MCP Server
+[![smithery badge](https://smithery.ai/badge/@felores/placid-mcp-server)](https://smithery.ai/server/@felores/placid-mcp-server)
 
 An MCP server implementation for integrating with Placid.app's API. This server provides tools for listing templates and generating creatives through the Model Context Protocol.
 
@@ -15,6 +16,14 @@ An MCP server implementation for integrating with Placid.app's API. This server 
 - Type-safe implementation
 
 ## Installation Options
+
+### Installing via Smithery
+
+To install @felores/placid-mcp-server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@felores/placid-mcp-server):
+
+```bash
+npx -y @smithery/cli install @felores/placid-mcp-server --client claude
+```
 
 ### Option 1: NPX Installation (Recommended)
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install @felores/placid-mcp-server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@felores/placid-mcp-server

Let me know if any tweaks have to be made!